### PR TITLE
Fix comment for syscall

### DIFF
--- a/_posts/2023-03-03-A-linking-adventure.md
+++ b/_posts/2023-03-03-A-linking-adventure.md
@@ -149,7 +149,7 @@ int main();
 // for the `exit` system call.
 void call_exit(int code, int exit_syscall_num) {
 	asm("mov %rsi, %rax;"  // Copy syscall number into %rax
-	    "syscall;");       // exit's arg is already in %rsi
+	    "syscall;");       // exit's arg is already in %rdi
 }
 
 void _start() { call_exit(main(), SYS_exit); }


### PR DESCRIPTION
(Still new to assembly here, so pardon me if I made a mistake here)

It seems like the first argument (arg0) of `exit` is the status, so this should be `rdi` instead of `rsi`.